### PR TITLE
Upgrade paper_trail dependency to 5.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    fast_versioning (0.1.0)
-      paper_trail (~> 4.2)
+    fast_versioning (0.1.3)
+      paper_trail (~> 5.0)
       rails
 
 GEM
@@ -45,31 +45,28 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (7.1.2)
+    arel (7.1.4)
     builder (3.2.2)
     concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
+    globalid (0.4.1)
+      activesupport (>= 4.2.0)
     i18n (0.7.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
     method_source (0.8.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (0.1.4)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
-    paper_trail (4.2.0)
+    paper_trail (5.2.3)
       activerecord (>= 3.0, < 6.0)
-      activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
     pkg-config (1.1.7)
     rack (2.0.1)
@@ -99,7 +96,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.2.2)
-    request_store (1.3.1)
+    request_store (1.3.2)
     rspec-core (3.5.2)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -117,10 +114,10 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -129,7 +126,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    websocket-driver (0.6.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
 
@@ -142,4 +139,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.12.5
+   1.15.4

--- a/fast_versioning.gemspec
+++ b/fast_versioning.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "fast_versioning"
-  s.version     = '0.1.2'
+  s.version     = '0.1.3'
   s.authors     = ['Arcadia Power', 'Iwo Dziechciarow', 'Justin Doody']
   s.email       = ['engineering@arcadiapower.com']
   s.homepage    = 'https://github.com/ArcadiaPower/fast-versioning'
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails'
-  s.add_dependency 'paper_trail', '~>4.2'
+  s.add_dependency 'paper_trail', '~> 5.0'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'

--- a/lib/fast_versioning/engine.rb
+++ b/lib/fast_versioning/engine.rb
@@ -1,5 +1,7 @@
 module FastVersioning
   class Engine < ::Rails::Engine
     isolate_namespace FastVersioning
+
+    PaperTrail.config.track_associations = false
   end
 end

--- a/spec/fast_versioning/fast_versioned_spec.rb
+++ b/spec/fast_versioning/fast_versioned_spec.rb
@@ -32,6 +32,7 @@ describe 'fast_versioned' do
 
     PaperTrail.enabled = true
     PaperTrail.enabled_for_controller = true
+    PaperTrail.config.track_associations = false
 
     PaperTrail::Version.module_eval do
       include FastVersioning::PaperTrailExtensions


### PR DESCRIPTION
The two config lines were added to silence deprecation warnings.

https://github.com/airblade/paper_trail/blob/master/CHANGELOG.md#500-2016-05-02