### PR TITLE
replace validation with db constraint

### DIFF
--- a/app/models/fast_versioning/fast_version.rb
+++ b/app/models/fast_versioning/fast_version.rb
@@ -4,8 +4,6 @@ module FastVersioning
     belongs_to :whodunnit, polymorphic: true
     belongs_to :version, class_name: 'PaperTrail::Version'
 
-    validates :version_id, uniqueness: { scope: :name }
-
     serialize :meta, JSON
   end
 end

--- a/db/migrate/20190514134359_add_unique_index_to_version_id_name.rb
+++ b/db/migrate/20190514134359_add_unique_index_to_version_id_name.rb
@@ -1,5 +1,7 @@
 class AddUniqueIndexToVersionIdName < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
   def change
-    add_index :fast_versioning_fast_versions, %i[version_id name], unique: true
+    add_index :fast_versioning_fast_versions, %i[version_id name], unique: true, algorithm: :concurrently
   end
 end

--- a/db/migrate/20190514134359_add_unique_index_to_version_id_name.rb
+++ b/db/migrate/20190514134359_add_unique_index_to_version_id_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToVersionIdName < ActiveRecord::Migration[5.0]
+  def change
+    add_index :fast_versioning_fast_versions, %i[version_id name], unique: true
+  end
+end

--- a/fast_versioning.gemspec
+++ b/fast_versioning.gemspec
@@ -1,9 +1,9 @@
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('../lib', __FILE__)
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "fast_versioning"
-  s.version     = '0.2.0'
+  s.name        = 'fast_versioning'
+  s.version     = '0.3.0'
   s.authors     = ['Arcadia Power', 'Iwo Dziechciarow', 'Justin Doody']
   s.email       = ['engineering@arcadiapower.com']
   s.homepage    = 'https://github.com/ArcadiaPower/fast-versioning'
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.0', '< 5.2'
   s.add_dependency 'paper_trail', '>= 4.2', '< 6'
 
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.13'
   s.add_development_dependency 'rspec-rails'
 end

--- a/spec/fast_versioning/fast_versioned_spec.rb
+++ b/spec/fast_versioning/fast_versioned_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../db/migrate/20160914161314_create_fast_versioning_fast_versions.rb', __dir__)
+require File.expand_path('../../db/migrate/20190514134359_add_unique_index_to_version_id_name', __dir__)
 
 describe 'fast_versioned' do
   before do
@@ -25,6 +26,7 @@ describe 'fast_versioned' do
       end
 
       CreateFastVersioningFastVersions.new.change
+      AddUniqueIndexToVersionIdName.new.change
     end
 
     # Rails would normally automatically load this.


### PR DESCRIPTION
**what**
- remove Rails level validation of `version_id, name` uniqueness
- add database unique index for `version_id, name`

**why**
Optimize db usage, a lot of queries (1 for every tracked version change) is performed during entries creation, and this should rearly/never be broken, uniqueness can be assured by a db constraint without generating additional queries