### PR TITLE
add AR 6.0 support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,29 +1,41 @@
 appraise 'ar-5.0_pt-4.0' do
   gem 'activerecord', '~> 5.0.0'
+  gem 'sqlite3', '~> 1.3.13'
   gem 'paper_trail', '~> 4.0'
 end
 
 appraise 'ar-5.0_pt-5.0' do
   gem 'activerecord', '~> 5.0.0'
+  gem 'sqlite3', '~> 1.3.13'
   gem 'paper_trail', '~> 5.0'
 end
 
 appraise 'ar-5.1_pt-4.0' do
   gem 'activerecord', '~> 5.1.0'
+  gem 'sqlite3', '~> 1.3.13'
   gem 'paper_trail', '~> 4.0'
 end
 
 appraise 'ar-5.1_pt-5.0' do
   gem 'activerecord', '~> 5.1.0'
+  gem 'sqlite3', '~> 1.3.13'
   gem 'paper_trail', '~> 5.0'
 end
 
 appraise 'ar-5.1_pt-10.3' do
   gem 'activerecord', '~> 5.1.0'
+  gem 'sqlite3', '~> 1.3.13'
   gem 'paper_trail', '~> 10.3'
 end
 
 appraise 'ar-5.2_pt-10.3' do
   gem 'activerecord', '~> 5.2.0'
+  gem 'sqlite3', '~> 1.3.13'
+  gem 'paper_trail', '~> 10.3'
+end
+
+appraise 'ar-6.0_pt-10.3' do
+  gem 'activerecord', '~> 6.0.0'
+  gem 'sqlite3', '~> 1.4'
   gem 'paper_trail', '~> 10.3'
 end

--- a/fast_versioning.gemspec
+++ b/fast_versioning.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,db,lib}/**/*', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '~> 5.0'
+  s.add_dependency 'rails', '>= 5.0', '< 6.1'
   s.add_dependency 'paper_trail', '>= 4.2'
 
-  s.add_development_dependency 'sqlite3', '~> 1.3.13'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'appraisal'
 end

--- a/gemfiles/ar_5.0_pt_4.0.gemfile
+++ b/gemfiles/ar_5.0_pt_4.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.13"
 gem "paper_trail", "~> 4.0"
 
 gemspec path: "../"

--- a/gemfiles/ar_5.1_pt_10.3.gemfile
+++ b/gemfiles/ar_5.1_pt_10.3.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
+gem "sqlite3", "~> 1.3.13"
 gem "paper_trail", "~> 10.3"
 
 gemspec path: "../"

--- a/gemfiles/ar_5.1_pt_4.0.gemfile
+++ b/gemfiles/ar_5.1_pt_4.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
+gem "sqlite3", "~> 1.3.13"
 gem "paper_trail", "~> 4.0"
 
 gemspec path: "../"

--- a/gemfiles/ar_5.1_pt_5.0.gemfile
+++ b/gemfiles/ar_5.1_pt_5.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
+gem "sqlite3", "~> 1.3.13"
 gem "paper_trail", "~> 5.0"
 
 gemspec path: "../"

--- a/gemfiles/ar_5.2_pt_10.3.gemfile
+++ b/gemfiles/ar_5.2_pt_10.3.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.2.0"
+gem "sqlite3", "~> 1.3.13"
 gem "paper_trail", "~> 10.3"
 
 gemspec path: "../"

--- a/gemfiles/ar_6.0_pt_10.3.gemfile
+++ b/gemfiles/ar_6.0_pt_10.3.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
-gem "sqlite3", "~> 1.3.13"
-gem "paper_trail", "~> 5.0"
+gem "activerecord", "~> 6.0.0"
+gem "sqlite3", "~> 1.4"
+gem "paper_trail", "~> 10.3"
 
 gemspec path: "../"


### PR DESCRIPTION
This PR expands the compatibility specifier for Rails 6.0.x and adds an appraisal for Rails 6.0.

The version of `sqlite3` specified by Rails changed in this version, so I moved it from the gemspec into the appraisals.